### PR TITLE
Optimize Dockerfiles

### DIFF
--- a/erlang_template/Dockerfile
+++ b/erlang_template/Dockerfile
@@ -1,16 +1,13 @@
-FROM ghcr.io/gleam-lang/gleam:v1.8.1-erlang-alpine
+FROM ghcr.io/gleam-lang/gleam:v1.8.1-erlang-alpine AS builder
 
 WORKDIR /build
-
 COPY . /build
 
-# Compile the project
-RUN cd /build \
-  && gleam export erlang-shipment \
-  && mv build/erlang-shipment /app \
-  && rm -r /build
+RUN gleam export erlang-shipment
 
-# Run the server
+FROM erlang:alpine
+
 WORKDIR /app
-ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["run"]
+COPY --from=builder /build/build/erlang-shipment .
+
+ENTRYPOINT [ "./entrypoint.sh", "run" ]

--- a/javascript_template/Dockerfile
+++ b/javascript_template/Dockerfile
@@ -1,20 +1,15 @@
-FROM ghcr.io/gleam-lang/gleam:v1.8.1-node-slim
-
-# Install Deno
-COPY --from=denoland/deno:bin-2.2.2 /deno /usr/local/bin/deno
-RUN chown -R 777 /usr/local/bin/deno
+FROM ghcr.io/gleam-lang/gleam:v1.8.1-node-slim AS builder
 
 WORKDIR /build
-
 COPY . /build
 
 # Compile the project
-RUN cd /build \
-  && gleam build --target javascript \
-  && mv build/dev/javascript /app \
-  && rm -r /build
+RUN gleam build --target javascript
 
-# Run the server
+FROM denoland/deno:alpine-2.2.2
+
 WORKDIR /app
+COPY --from=builder /build/build/dev/javascript /app
+
 RUN echo "main()" >> /app/javascript_template/javascript_template.mjs
 CMD ["deno", "--allow-net", "/app/javascript_template/javascript_template.mjs"]


### PR DESCRIPTION
Hi there! I'm not smart enough to build a chess bot, but wanted to help a little bit.

I added build steps to the Dockerfiles. They are much smaller now (especially the js one).

```bash
# Erlang Image
> docker inspect chess:old --format='{{.Size}}' | numfmt --to=iec
114M
> docker inspect chess:new --format='{{.Size}}' | numfmt --to=iec
86M

# JS Image
> docker inspect chessjs:old --format='{{.Size}}' | numfmt --to=iec
485M

> docker inspect chessjs:new --format='{{.Size}}' | numfmt --to=iec
137M
```